### PR TITLE
fixes screenshot in Marketplace description

### DIFF
--- a/SignPathExtension.md
+++ b/SignPathExtension.md
@@ -9,7 +9,7 @@ Supported file formats: EXE, DLL, PowerShell, MSI, CAB, AppX, nupkg, Office add-
 
 After installing the extension, you can add one (or more) of the tasks to a new or existing build definition.
 
-![Screenshot](./images/screenshot-extension.png)
+![Screenshot](images/screenshot-extension.png)
 
 ## Available tasks
 

--- a/_version.ps1
+++ b/_version.ps1
@@ -1,3 +1,3 @@
 $_MajorVersion = 1
 $_MinorVersion = 0
-$_PatchVersion = 4
+$_PatchVersion = 5


### PR DESCRIPTION
Screenshot on https://marketplace.visualstudio.com/items?itemName=SignPath.signpath-tasks did not work. Apparently, relative references (that work when opening the file in GitHub) don't work. See e.g. https://github.com/microsoft/google-play-vsts-extension on how they dit it.