### PR TITLE
New major version: use newest PowerShell script major version & use k…

### DIFF
--- a/_version.ps1
+++ b/_version.ps1
@@ -1,3 +1,3 @@
-$_MajorVersion = 1
+$_MajorVersion = 2
 $_MinorVersion = 0
-$_PatchVersion = 5
+$_PatchVersion = 0

--- a/signPathDownloadSignedArtifactTask/SignPathDownloadSignedArtifactTask.ps1
+++ b/signPathDownloadSignedArtifactTask/SignPathDownloadSignedArtifactTask.ps1
@@ -13,7 +13,8 @@ try {
   [string]$apiUrl = Get-VstsInput -Name apiUrl
   [string]$waitForCompletionTimeoutInSeconds = Get-VstsInput -Name waitForCompletionTimeoutInSeconds
   
-  Install-Module -Name SignPath -MinimumVersion 1.2.0 -MaximumVersion 1.2.0 -Scope CurrentUser -Force
+  # Install the highest minor/patch version of the module
+  Install-Module -Name SignPath -MinimumVersion 2.0.0 -MaximumVersion 2.999.999 -Scope CurrentUser -Force
   
   $arguments = @{}
   $arguments["ApiUrl"] = $apiUrl

--- a/signPathSubmitSigningRequestTask/SignPathSubmitSigningRequestTask.ps1
+++ b/signPathSubmitSigningRequestTask/SignPathSubmitSigningRequestTask.ps1
@@ -8,15 +8,16 @@ try {
   [string]$waitForCompletion = Get-VstsInput -Name waitForCompletion
   [string]$inputArtifactPath = Get-VstsInput -Name inputArtifactPath
   [string]$organizationId = Get-VstsInput -Name organizationId
-  [string]$projectName = Get-VstsInput -Name projectName
-  [string]$signingPolicyName = Get-VstsInput -Name signingPolicyName
-  [string]$artifactConfigurationName = Get-VstsInput -Name artifactConfigurationName
+  [string]$projectKey = Get-VstsInput -Name projectKey
+  [string]$signingPolicyKey = Get-VstsInput -Name signingPolicyKey
+  [string]$artifactConfigurationKey = Get-VstsInput -Name artifactConfigurationKey
   [string]$ciUserToken = Get-VstsInput -Name ciUserToken
   [string]$inputArtifactDescription = Get-VstsInput -Name inputArtifactDescription
   [string]$apiUrl = Get-VstsInput -Name apiUrl
   [string]$waitForCompletionTimeoutInSeconds = Get-VstsInput -Name waitForCompletionTimeoutInSeconds
 
-  Install-Module -Name SignPath -MinimumVersion 1.2.0 -MaximumVersion 1.2.0 -Scope CurrentUser -Force
+  # Install the highest minor/patch version of the module
+  Install-Module -Name SignPath -MinimumVersion 2.0.0 -MaximumVersion 2.999.999 -Scope CurrentUser -Force
   
   $inputArtifactPath = Find-VstsMatch -Pattern $inputArtifactPath
   
@@ -24,9 +25,9 @@ try {
   $arguments["ApiUrl"] = $apiUrl
   $arguments["CIUserToken"] = $ciUserToken
   $arguments["OrganizationId"] = $organizationId
-  $arguments["ProjectName"] = $projectName
-  $arguments["ArtifactConfigurationName"] = $artifactConfigurationName
-  $arguments["SigningPolicyName"] = $signingPolicyName
+  $arguments["ProjectKey"] = $projectKey
+  $arguments["ArtifactConfigurationKey"] = $artifactConfigurationKey
+  $arguments["SigningPolicyKey"] = $signingPolicyKey
   $arguments["InputArtifactPath"] = $inputArtifactPath
   $arguments["Description"] = $inputArtifactDescription
   

--- a/signPathSubmitSigningRequestTask/task.json
+++ b/signPathSubmitSigningRequestTask/task.json
@@ -11,7 +11,7 @@
                     "Minor":  0,
                     "Patch":  0
                 },
-    "instanceNameFormat":  "SignPath SubmitSigningRequest $(projectName) / $(signingPolicyName)",
+    "instanceNameFormat":  "SignPath SubmitSigningRequest $(projectKey) / $(signingPolicyKey)",
     "groups":  [
                    {
                        "name":  "advanced",
@@ -57,28 +57,28 @@
                        "helpMarkDown":  "Your SignPath organization ID. If you don\u0027t know it, log into SignPath and go to the organization details page."
                    },
                    {
-                       "name":  "projectName",
+                       "name":  "projectKey",
                        "type":  "string",
-                       "label":  "Project name",
+                       "label":  "Project key",
                        "defaultValue":  "",
                        "required":  true,
-                       "helpMarkDown":  "The project name. If you don\u0027t know it, log into SignPath, go to the projects list page and select one of the projects."
+                       "helpMarkDown":  "The project key. If you don\u0027t know it, log into SignPath, go to the projects list page and select one of the projects."
                    },
                    {
-                       "name":  "signingPolicyName",
+                       "name":  "signingPolicyKey",
                        "type":  "string",
-                       "label":  "Signing policy name",
+                       "label":  "Signing policy key",
                        "defaultValue":  "",
                        "required":  true,
-                       "helpMarkDown":  "The signing policy name. If you don\u0027t know it, log into SignPath, go to the project\u0027s details page and select one of the signing policies."
+                       "helpMarkDown":  "The signing policy key. If you don\u0027t know it, log into SignPath, go to the project\u0027s details page and select one of the signing policies."
                    },
                    {
-                       "name":  "artifactConfigurationName",
+                       "name":  "artifactConfigurationKey",
                        "type":  "string",
-                       "label":  "Artifact configuration name (optional)",
+                       "label":  "Artifact configuration key (optional)",
                        "defaultValue":  "",
                        "required":  false,
-                       "helpMarkDown":  "The artifact configuration name. If left empty, the default artifact configuration is selected. If you don\u0027t know it, log into SignPath, go to the project\u0027s details page and select one of the artifact configurations."
+                       "helpMarkDown":  "The artifact configuration key. If left empty, the default artifact configuration is selected. If you don\u0027t know it, log into SignPath, go to the project\u0027s details page and select one of the artifact configurations."
                    },
                    {
                        "name":  "outputArtifactPath",


### PR DESCRIPTION
- Merge immediately after PROD release 1.51
- After the new major version has been released
-- Create a new branch that uses the new major version in the azure-pipelines.yml of the repo
-- Use keys instead of names in the azure-pipeliney.yml
-- Check whether the branch still builds, if yes, increase the version to 2.0.1 in the _version.ps1 and merge to master.
